### PR TITLE
Add Google translation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ const lilith = new LilithEve({
 - Subconscious pattern recognition
 - Integration with psychological treatment plans
 
+## 🈺 Google Translation Service Integration
+A lightweight `GoogleTranslateService` enables translation via Google Cloud. Configure `GOOGLE_CLOUD_API_KEY` (or `GOOGLE_TRANSLATE_API_KEY`) in your `.env` file.
 ## 📚 **Documentation**
 
 - 📖 [Architecture Guide](./docs/ARCHITECTURE.md) - Detailed system design

--- a/env.example
+++ b/env.example
@@ -106,6 +106,7 @@ BLOOD_PRESSURE_API_KEY=your_blood_pressure_api_key
 # ============================================================================
 DEEPL_API_KEY=your_deepl_api_key
 GOOGLE_TRANSLATE_API_KEY=your_google_translate_api_key
+GOOGLE_CLOUD_API_KEY=your_google_cloud_api_key
 SUPPORTED_LANGUAGES=en,es,fr,de,zh,ja,ko,ar,hi
 
 # ============================================================================

--- a/src/services/google-translate.service.ts
+++ b/src/services/google-translate.service.ts
@@ -1,0 +1,26 @@
+import axios from 'axios'
+
+export class GoogleTranslateService {
+  private apiKey: string
+
+  constructor(apiKey: string = process.env.GOOGLE_CLOUD_API_KEY || process.env.GOOGLE_TRANSLATE_API_KEY || '') {
+    this.apiKey = apiKey
+  }
+
+  async translate(text: string, targetLanguage: string): Promise<string> {
+    if (!this.apiKey) {
+      throw new Error('Google API key not provided')
+    }
+
+    const url = 'https://translation.googleapis.com/language/translate/v2'
+    const response = await axios.post(url, null, {
+      params: {
+        q: text,
+        target: targetLanguage,
+        key: this.apiKey,
+      },
+    })
+
+    return response.data.data.translations[0].translatedText as string
+  }
+}


### PR DESCRIPTION
## Summary
- implement `GoogleTranslateService`
- document new translation service and API key in README
- add `GOOGLE_CLOUD_API_KEY` to env.example

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68808021b2848325b9a534b4187d4cc1